### PR TITLE
Adjust styling for AnswerCard component

### DIFF
--- a/src/components/AnswerCard.tsx
+++ b/src/components/AnswerCard.tsx
@@ -14,12 +14,12 @@ export default function AnswerCard({ answer, onClick }: AnswerProps) {
       key={answer.id}
       onClick={onClick}
       className={`
-    flex justify-between items-center p-4 rounded-lg cursor-pointer
+    flex justify-between items-center p-2 lg:p-6 rounded-lg cursor-pointer
     ${answer.revealed ? "bg-blue-600" : "bg-gray-700"}
-    transition-all duration-300 h-16
+    transition-all duration-300 lg:h-32 w-full
   `}
     >
-      <div className="font-bold text-xl">
+      <div className="font-bold lg:text-xl px-2">
         {answer.revealed ? answer.text : "?"}
       </div>
       <div


### PR DESCRIPTION
This PR modifies padding and height for the AnswerCard component to improve layout and responsiveness. Fixes #25

<img width="389" alt="image" src="https://github.com/user-attachments/assets/f2f2bb51-6177-42b0-9c67-68b7894e01f6" />


https://github.com/user-attachments/assets/7b1d06b9-2886-48d9-8e25-97fad57af616

